### PR TITLE
restrict access to quota information

### DIFF
--- a/specs.wdio/browser_sdk/quota.spec.ts
+++ b/specs.wdio/browser_sdk/quota.spec.ts
@@ -148,4 +148,24 @@ describe('quota', () => {
     expect(beforeQuotaViolation.remainingStorageAvailable)
       .to.be.eq(afterQuotaViolation.remainingStorageAvailable);
   });
+
+  it('does not allow to lookup other users quota', async () => {
+    const [user1, user2] = await Session.getTwoSessions();
+
+    const quota = await user1.getQuota(await user2.getActorId());
+
+    expect(quota).to.eql({});
+  });
+
+  it('does not allow to lookup quota if the user is not member of the attribute', async () => {
+    const [user1, user2] = await Session.getTwoSessions();
+
+    const team = await user1.Attribute.createKeyValue({});
+
+    const authorizedQuotaLookup = await user1.getQuota(team.id);
+    const unauthorizedQuotaLookup = await user2.getQuota(team.id);
+
+    expect(unauthorizedQuotaLookup).to.eql({});
+    expect(authorizedQuotaLookup).to.not.eql({});
+  });
 });

--- a/src/facts/server/index.ts
+++ b/src/facts/server/index.ts
@@ -180,6 +180,26 @@ export default class Fact {
     }
   }
 
+  public static async isAuthorizedToReadQuota(
+    nodeId: string,
+    userid: string,
+    logger: IsLogger,
+  ): Promise<boolean> {
+    assert(nodeId, 'nodeId needs to be provided in isAuthorizedToReadQuota');
+    assert(userid, 'userid needs to be provided in isAuthorizedToReadQuota');
+
+    if (nodeId === userid) {
+      return true;
+    }
+
+    return Fact.hasAccess(
+      userid,
+      ['creator', 'host', 'member', 'access'],
+      nodeId,
+      logger,
+    );
+  }
+
   public static async isAuthorizedToManageQuota(
     nodeId: string,
     userid: string,

--- a/src/server/controllers/quota_controller.ts
+++ b/src/server/controllers/quota_controller.ts
@@ -7,6 +7,15 @@ export default {
       throw new Error('no nodeId given to retrieve quota');
     }
 
+    if (!await Fact.isAuthorizedToReadQuota(
+      req.params.nodeId,
+      req.hashedUserID,
+      req.log,
+    )) {
+      res.send({});
+      return;
+    }
+
     const quota = new Quota(req.params.nodeId, req.log);
 
     const asAccountee = await Fact.isAuthorizedToManageQuota(

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -14,6 +14,7 @@ exports.config = {
     tinytodo: ['./specs.wdio/tinytodo/**/*.spec.ts'],
     auth: ['./specs.wdio/**/auth.spec.ts'],
     quota_upgrade: ['./specs.wdio/quota_upgrade/**/*.spec.ts'],
+    quota: ['./specs.wdio/browser_sdk/**/quota.spec.ts'],
     browser_sdk: ['./specs.wdio/browser_sdk/**/*.spec.ts'],
     load: ['./specs.wdio/load/**/*.spec.ts'],
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced stricter access control for viewing quota information, ensuring users can only access quota data for nodes they are authorized to view.

- **Bug Fixes**
  - Users now receive an empty result when attempting to view quota data for nodes they do not have permission to access.

- **Tests**
  - Added new test cases to verify quota visibility is correctly restricted by user identity and membership.

- **Chores**
  - Updated test suite configuration to include quota-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->