### PR TITLE
fix creation of attributes if assigned facts use  placeholder

### DIFF
--- a/specs/browser_sdk/attribute.spec.ts
+++ b/specs/browser_sdk/attribute.spec.ts
@@ -707,4 +707,28 @@ describe('Attribute', () => {
       expect(references.length).to.equal(0);
     });
   });
+
+  describe('Attribute.create()', () => {
+    it('allows to specify "$it" as subject placeholder', async () => {
+      const [client] = await createClient();
+
+      await client.Fact.createAll([
+        ['Thing', '$isATermFor', 'some category'],
+      ]);
+
+      const attr = await client.Attribute.create('keyValue', {}, [
+        ['$it', 'isA', 'Thing'],
+      ]);
+
+      const { retrieved } = await client.Attribute.findAll({
+        retrieved: [
+          ['$it', 'isA', 'Thing'],
+        ],
+      });
+
+      expect(retrieved).to.not.equal(undefined);
+      expect(retrieved.length).to.equal(1);
+      expect(retrieved[0]!.id).to.equal(attr.id);
+    });
+  });
 });

--- a/src/browser_sdk/index.ts
+++ b/src/browser_sdk/index.ts
@@ -240,6 +240,10 @@ export default class LinkedRecords {
     // If OIDC is enabled and access token is available, use Bearer token
     if (this.oidcManager) {
       const accessToken = await this.oidcManager.getAccessToken();
+
+      // FIXME: if we do not hav a token but still are in public client mode,
+      // the userInfo request will fail because of CORS which tries to send
+      // cookies to the domain
       if (accessToken) {
         mergedHeaders['Authorization'] = `Bearer ${accessToken}`;
         // For cross-origin, do not send cookies if using Bearer

--- a/src/server/controllers/attributes_controller.ts
+++ b/src/server/controllers/attributes_controller.ts
@@ -128,8 +128,8 @@ export default class Controller {
         if (rawFact.length === 3 && rawFact[0] === '$it') {
           return new Fact(
             attributesInCreation,
-            rawFact[0],
             rawFact[1],
+            rawFact[2],
             req.log,
           );
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved support for using "$it" as a subject placeholder when creating attributes.
- Bug Fixes
  - Fixed attribute creation with "$it" so created attributes are correctly retrievable and consistent.
- Documentation
  - Added an internal note clarifying access token behavior in public client mode; no functional changes.
- Tests
  - Added test coverage to validate "$it" placeholder handling during attribute creation and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->