### PR TITLE
Batch accountability fact placement for new-graph compositions

### DIFF
--- a/src/facts/server/fact_box.ts
+++ b/src/facts/server/fact_box.ts
@@ -28,6 +28,19 @@ export default class FactBox {
     return newFactBoxIdResult.rows[0].id;
   }
 
+  // A fresh graph in the user's own fact box. Facts of a composition which
+  // does not connect to any existing graph can be placed here directly,
+  // without going through per-fact placement resolution.
+  public static async createNewUserScopedFactBox(
+    userId: string,
+    logger: IsLogger,
+  ): Promise<FactBox> {
+    return new FactBox(
+      await FactBox.getInternalUserId(userId, logger),
+      await FactBox.getNewGraphId(logger),
+    );
+  }
+
   static async getFactBoxPlacement(userId: string, fact: Fact, logger: IsLogger): Promise<FactBox> {
     const internalUserId = await FactBox.getInternalUserId(userId, logger);
 

--- a/src/facts/server/index.ts
+++ b/src/facts/server/index.ts
@@ -437,21 +437,13 @@ export default class Fact {
   static async saveAllWithoutAuthCheck(
     facts: Fact[],
     userid: string,
-    isNewUserScopedGraph: boolean | undefined,
+    newUserScopedGraphBox: FactBox | undefined,
     logger: IsLogger,
   ): Promise<FactBox | undefined> {
     if (facts.length === 0) return undefined;
 
     const specialFacts = facts.filter((fact) => fact.hasSpecialCreationLogic());
     const nonSpecialFacts = facts.filter((fact) => !fact.hasSpecialCreationLogic());
-    let factPlacement: FactBox | undefined;
-
-    if (isNewUserScopedGraph) {
-      factPlacement = {
-        id: await FactBox.getInternalUserId(userid, logger),
-        graphId: await FactBox.getNewGraphId(logger),
-      };
-    }
 
     for (let i = 0; i < specialFacts.length; i += 1) {
       // we need to create this one by one to make sure no
@@ -463,15 +455,11 @@ export default class Fact {
     await this.saveAllWithoutAuthCheckAndSpecialTreatment(
       nonSpecialFacts,
       userid,
-      factPlacement,
+      newUserScopedGraphBox,
       logger,
     );
 
-    if (isNewUserScopedGraph) {
-      return factPlacement;
-    }
-
-    return undefined;
+    return newUserScopedGraphBox;
   }
 
   static async saveAllWithoutAuthCheckAndSpecialTreatment(
@@ -985,20 +973,6 @@ export default class Fact {
     });
 
     return !connectingFact;
-  }
-
-  static async moveAllAccountabilityFactsToFactBox(
-    attributeIds: string[],
-    factBox: FactBox,
-    logger: IsLogger,
-  ) {
-    const pool = new PgPoolWithLog(logger);
-    const attributeString = attributeIds.map((id) => `'${EnsureIsValid.nodeId(id)}'`).join(',');
-
-    await pool.query(`UPDATE facts SET fact_box_id=$1, graph_id=$2 WHERE predicate='$isAccountableFor' AND object IN (${attributeString})`, [
-      factBox.id,
-      factBox.graphId,
-    ]);
   }
 
   static areKnownSubjects(nodeIds: string[], logger: IsLogger): Promise<boolean> {

--- a/src/records/abstract/abstract_record_server.ts
+++ b/src/records/abstract/abstract_record_server.ts
@@ -4,6 +4,7 @@ import SerializedChangeWithMetadata from './serialized_change_with_metadata';
 import IsSerializable from './is_serializable';
 import IsLogger from '../../../lib/is_logger';
 import Fact from '../../facts/server';
+import FactBox from '../../facts/server/fact_box';
 import QueryExecutor from '../record_query';
 
 export type LoadResult<T> = {
@@ -98,11 +99,31 @@ export default abstract class AbstractRecordServer <
     throw new Error('getDataTypePrefix needs to be implemented in child class');
   }
 
+  // When factBox is given, the caller guarantees that all records are part of
+  // a new graph which lives in this box (see Fact.isNewUserScopedGraph). The
+  // accountability facts can then be placed there directly in one batch
+  // instead of resolving a fact box placement for each of them.
   public static async createAll(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     attr: [AbstractRecordServer<any, any>, any][],
+    factBox?: FactBox,
   ): Promise<string[]> {
-    const result = await Promise.all(attr.map(([a, v]) => a.create(v)));
+    const first = attr[0];
+
+    if (!first || !factBox) {
+      const result = await Promise.all(attr.map(([a, v]) => a.create(v)));
+
+      return result.map((r) => r.id);
+    }
+
+    await Fact.saveAllWithoutAuthCheckAndSpecialTreatment(
+      attr.map(([a]) => new Fact(a.actorId, '$isAccountableFor', a.id, a.logger)),
+      first[0].actorId,
+      factBox,
+      first[0].logger,
+    );
+
+    const result = await Promise.all(attr.map(([a, v]) => a.createWithoutAccountableFact(v)));
 
     return result.map((r) => r.id);
   }
@@ -113,6 +134,10 @@ export default abstract class AbstractRecordServer <
   }
 
   abstract create(
+    value: Type
+  ) : Promise<{ id: string }>;
+
+  abstract createWithoutAccountableFact(
     value: Type
   ) : Promise<{ id: string }>;
 

--- a/src/records/blob/server/index.ts
+++ b/src/records/blob/server/index.ts
@@ -65,6 +65,10 @@ BlobChange
   async create(value: Blob) : Promise<{ id: string }> {
     await this.createAccountableFact();
 
+    return this.createWithoutAccountableFact(value);
+  }
+
+  async createWithoutAccountableFact(value: Blob) : Promise<{ id: string }> {
     return this.storage.createRecord(this.id, this.actorId, await this.marshal(value));
   }
 

--- a/src/records/key_value/server/index.ts
+++ b/src/records/key_value/server/index.ts
@@ -7,6 +7,7 @@ import SerializedChangeWithMetadata from '../../abstract/serialized_change_with_
 import KeyValueChange from '../key_value_change';
 import QueuedTasks, { IsQueue } from '../../../../lib/queued-tasks';
 import Fact from '../../../facts/server';
+import FactBox from '../../../facts/server/fact_box';
 import IsLogger from '../../../../lib/is_logger';
 import AttributeStorage from '../../record_storage/psql';
 
@@ -25,6 +26,7 @@ KeyValueChange
   public static async createAll(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     attr: [AbstractRecordServer<any, any>, any][],
+    factBox?: FactBox,
   ): Promise<string[]> {
     if (!attr[0]) {
       throw new Error('invalid attribute data found when creating all attributes');
@@ -33,7 +35,7 @@ KeyValueChange
     await Fact.saveAllWithoutAuthCheckAndSpecialTreatment(
       attr.map(([a]) => new Fact(a.actorId, '$isAccountableFor', a.id, a.logger)),
       attr[0][0].actorId,
-      undefined,
+      factBox,
       attr[0][0].logger,
     );
 
@@ -95,6 +97,10 @@ KeyValueChange
 
   async create(value: object) : Promise<{ id: string }> {
     await this.createAccountableFact();
+    return this.createWithoutAccountableFact(value);
+  }
+
+  async createWithoutAccountableFact(value: object) : Promise<{ id: string }> {
     return this.storage.createRecord(this.id, this.actorId, JSON.stringify(value));
   }
 

--- a/src/records/long_text/server/index.ts
+++ b/src/records/long_text/server/index.ts
@@ -45,6 +45,10 @@ LongTextChange
   async create(value: string) : Promise<{ id: string }> {
     await this.createAccountableFact();
 
+    return this.createWithoutAccountableFact(value);
+  }
+
+  async createWithoutAccountableFact(value: string) : Promise<{ id: string }> {
     return this.storage.createRecord(this.id, this.actorId, value);
   }
 

--- a/src/server/controllers/records_controller.ts
+++ b/src/server/controllers/records_controller.ts
@@ -5,6 +5,7 @@ import { uuidv7 as uuid } from 'uuidv7';
 import SerializedChangeWithMetadata from '../../records/abstract/serialized_change_with_metadata';
 import QueryExecutor, { RecordQuery, ResolveToRecordsResult } from '../../records/record_query';
 import Fact from '../../facts/server';
+import FactBox from '../../facts/server/fact_box';
 import PgPoolWithLog from '../../../lib/pg-log';
 import Quota from '../quota';
 import AuthCache from '../../facts/server/auth_cache';
@@ -290,22 +291,26 @@ export default class Controller {
       log,
     );
 
+    // When the composition does not connect to any existing graph, all its
+    // facts - including the accountability facts of the new records - end up
+    // in one fresh graph. Computing that placement upfront allows the record
+    // classes to batch-insert the accountability facts instead of resolving
+    // a placement for each one.
+    const compositionFactBox = isNewUserScopedGraph && resolvedFacts.length
+      ? await FactBox.createNewUserScopedFactBox(hashedUserID, log)
+      : undefined;
+
     const attributesToSaveEntries = Array.from(attributesByAttributeClass.entries());
     const attributeSavePromises = attributesToSaveEntries
-      .map(([AC, attributesAndValues]) => AC.createAll(attributesAndValues));
-    const savedAttributeIds = await Promise.all(attributeSavePromises).then((r) => r.flat());
+      .map(([AC, attributesAndValues]) => AC.createAll(attributesAndValues, compositionFactBox));
+    await Promise.all(attributeSavePromises);
 
-    // TODO: This is slow
-    const factBox = await Fact.saveAllWithoutAuthCheck(
+    await Fact.saveAllWithoutAuthCheck(
       resolvedFacts,
       hashedUserID,
-      isNewUserScopedGraph,
+      compositionFactBox,
       log,
     );
-
-    if (factBox) {
-      await Fact.moveAllAccountabilityFactsToFactBox(savedAttributeIds, factBox, log);
-    }
 
     return Controller.getCompositionResult(composition, nameIdMap);
   }


### PR DESCRIPTION
When a composition does not connect to any existing graph (isNewUserScopedGraph), its fact box placement is now computed once upfront and passed into the record classes. The accountability facts of the new records are batch-inserted directly into that box instead of resolving a placement (SELECT + nextval + INSERT) for each fact sequentially, and the moveAllAccountabilityFactsToFactBox cleanup UPDATE is no longer needed.

Compositions that connect to an existing graph keep the sequential placement path unchanged, since later facts may rely on auth facts and placements written earlier in the same request.

Reduces SQL queries for the load test's createDocument blueprint from 76 to 42 per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved creation of user-scoped fact boxes for compositions.
  - Composition attributes and related facts can now be created together within the same scope.
  - Added more efficient batch creation for records and their associated accountability information.

- **Bug Fixes**
  - Improved consistency when creating new user-scoped compositions and records.
  - Preserved existing creation behavior when no scoped fact box is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->