### PR TITLE
Add introduction video to README and docs homepage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,8 @@ LinkedRecords is a Backend-as-a-Service you can connect to directly from your si
 - **SDKs on npm:** [`@linkedrecords/browser`](https://www.npmjs.com/package/@linkedrecords/browser) (core SDK) · [`@linkedrecords/react`](https://www.npmjs.com/package/@linkedrecords/react) (React hooks)
 - **License:** [MIT](LICENSE)
 
+[![LinkedRecords Introduction](https://img.youtube.com/vi/qdGSEJaJS78/maxresdefault.jpg)](https://www.youtube.com/watch?v=qdGSEJaJS78)
+
 ## Quickstart
 
 Run the backend locally with Docker (includes PostgreSQL and a mock OIDC provider with one-click test accounts):

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -10,6 +10,16 @@ description: LinkedRecords - A Backend-as-a-Service for collaborative SaaS appli
 
 LinkedRecords makes all of this possible. It's not just another BaaS - it's a fundamentally different architecture for building collaborative applications.
 
+<div className="aspect-video w-full my-6">
+  <iframe
+    className="w-full h-full rounded-lg border"
+    src="https://www.youtube.com/embed/qdGSEJaJS78"
+    title="LinkedRecords Introduction"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  />
+</div>
+
 # LinkedRecords
 
 LinkedRecords is a Backend-as-a-Service that you can connect to directly from your single-page application - no backend code required. Think of it as a database you can call directly from your React app, with authorization built in and real-time collaboration out of the box.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a linked YouTube introduction thumbnail near the top of the README.
  * Embedded an introductory YouTube video on the documentation homepage with responsive display and fullscreen support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->